### PR TITLE
fix(virtual.ts): automatically recompute range on uniqueIds change

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -5,12 +5,14 @@ import HomePage from './pages/home';
 const FixedSizePage = lazy(() => import('./pages/fixed'));
 const DynamicSizePage = lazy(() => import('./pages/dynamic'));
 const SlotPage = lazy(() => import('./pages/slot'));
+const ReactivePage = lazy(() => import('./pages/reactive'));
 
 const routes = [
   { name: 'Home', href: '/' },
   { name: 'Fixed Size', href: '/fixed' },
   { name: 'Dynamic Size', href: '/dynamic' },
   { name: 'Slot', href: '/slot' },
+  { name: 'Reactive', href: '/reactive' },
 ];
 
 const App: SolidComponent = () => {
@@ -36,6 +38,7 @@ const App: SolidComponent = () => {
           <Route path="/fixed" component={FixedSizePage} />
           <Route path="/dynamic" component={DynamicSizePage} />
           <Route path="/slot" component={SlotPage} />
+          <Route path="/reactive" component={Reactive} />
         </Routes>
       </main>
     </div>

--- a/demo/src/pages/home/index.tsx
+++ b/demo/src/pages/home/index.tsx
@@ -21,6 +21,8 @@ const HomePage = () => {
             <br />
             <span>• Fixed header and footer slot</span>
             <br />
+            <span>• Reactivity for list when data grows/shrinks</span>
+            <br />
           </div>
         </div>
       </div>

--- a/demo/src/pages/reactive/index.tsx
+++ b/demo/src/pages/reactive/index.tsx
@@ -1,0 +1,55 @@
+import { createSignal } from 'solid-js';
+import SolidVirtualList from '@kenh24/solid-virtual-list';
+
+interface Data {
+  id: string;
+  height: string;
+}
+
+const [dataSource, setDataSource] = createSignal(
+  new Array(25).fill(0).map((_, index) => ({
+    id: `${index}-${Math.random()}`,
+    height: `${Math.floor(Math.random() * 60 + 60)}px`,
+  })
+));
+
+const addItem = () => {
+  setDataSource(prev => [
+    ...prev,
+    {
+      id: `${prev.length}-${Math.random()}`,
+      height: `${Math.floor(Math.random() * 60 + 60)}px`,
+    }
+  ]);
+};
+  
+
+const Reactive = () => {
+  return (
+    <div class="flex flex-col items-center">
+      <div class="min-w-[800px] py-6">
+        <div class="text-2xl mb-4">Dynamic Size Virtual List</div>
+        <div class="w-full h-[600px]  border-gray-900 text-gray-900 border-[1px] rounded-md">
+          <SolidVirtualList<Data>
+            estimateSize={80}
+            dataSource={dataSource}
+            dataId={'id'}
+            header={{ render: () => <button onClick={() => addItem()}>Add Item</button> }}
+            itemRender={(index, data) => {
+              const height = data.height;
+
+              return (
+                <div class="h-[60px] w-full px-[10px] flex items-center border-b-[1px] border-gray-900  box-border" style={{ height }}>
+                  <span># {index}</span>
+                  <span class="ml-4 font-semibold text-gray-900">height = {height}</span>
+                </div>
+              );
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Reactive;

--- a/solid-virtual-list/src/virtual-list/virtual.ts
+++ b/solid-virtual-list/src/virtual-list/virtual.ts
@@ -169,6 +169,7 @@ export class Virtual {
         this.sizesMap.delete(id);
       }
     }
+    this.forceUpdate(this.params.offset);
   }
 
   private isFixedSize() {


### PR DESCRIPTION
**Type:** Bug‑fix / Enhancement

---

Right now, calling `virtual.updateUniqueIds(...)` merely swaps in a new ID array, but it doesn’t recalculate the visible window unless you also call `forceUpdate(...)` or perform a scroll. When data source grows/shrinks without scrolling, nothing updates until the next user scroll or a hot‑reload (in dev).

This patch makes `updateUniqueIds` immediately invoke `forceUpdate` at the current offset, so any data‑only changes automatically redraw the list.

---

**Changelog entry:**

### Fixed
- VirtualList no longer “stalls” when its dataSource changes without scroll—visible range is now recomputed on every `updateUniqueIds`.

---

**Test**

Added simple smoke test in a demo labeled "reactive".
