### PR TITLE
Fix scroll jumps in multi-list SolidVirtualList scenarios 

### DIFF
--- a/solid-virtual-list/src/virtual-list/index.tsx
+++ b/solid-virtual-list/src/virtual-list/index.tsx
@@ -30,19 +30,26 @@ const SolidVirtualList = <T,>(props: SolidVirtualListProps<T>) => {
 
   const isHorizontal = createMemo(() => mergedProps.direction === 'horizontal');
   const rendered = createMemo(() => mergedProps.dataSource.slice(start(), end()));
+  const memoizedDataSource = createMemo(() => mergedProps.dataSource);
   const dataSourceIds = createMemo(() => {
     const dataId = mergedProps.dataId;
-    const dataSource = mergedProps.dataSource;
+    const dataSource = memoizedDataSource();
     return dataSource.map((data) => (typeof dataId === 'function' ? dataId(data) : (data as any)?.[dataId]));
   });
+  const [ prevIds, setPrevIds ] = createSignal<string[]>(dataSourceIds());
 
   onMount(() => {
     virtual.forceUpdate((isHorizontal() ? ref()?.scrollLeft : ref()?.scrollTop) || 0);
   });
 
   createEffect(() => {
-    const newDataSourceIds = dataSourceIds();
-    virtual.updateUniqueIds(newDataSourceIds);
+    if (
+      dataSourceIds().length !== prevIds().length || 
+      dataSourceIds().some((id, i) => id !== prevIds()[i])
+    ) {
+      virtual.updateUniqueIds(dataSourceIds());
+      setPrevIds([...dataSourceIds()]);
+    } 
   });
 
   const virtual = new Virtual(


### PR DESCRIPTION
### Problem
Commit `290bcbd` added `forceUpdate` to `Virtual.updateUniqueIds` to ensure `dataSource` changes are reflected immediately in single-list scenarios, fixing stale rendering and covering growing/shrinking lists. However, in applications with multiple `SolidVirtualList` instances (e.g., multiple virtualized lists in a single parent component), this caused unintended scroll jumps. Parent re-renders triggered the `createEffect` for `dataSourceIds` in all instances, calling `updateUniqueIds` and `forceUpdate` even when their `dataSource` was unchanged, leading to unnecessary range updates and scroll position shifts.

### Approach
To maintain the benefits of `290bcbd` (immediate updates for modified lists) while preventing scroll jumps in multi-list setups, I've optimized `SolidVirtualList`’s reactivity to ensure `updateUniqueIds` is only called when a list’s `dataSource` IDs change. I also improved initial rendering to avoid unnecessary updates.

### Changes
- **Memoized `dataSource`**: Added `memoizedDataSource` using `createMemo` to prevent `dataSourceIds` recomputation when the `dataSource` prop reference changes but content is identical.
- **Added `prevIds` Signal**: Introduced a `prevIds` signal to track previous `dataSourceIds`. The `createEffect` now checks if `dataSourceIds` differs from `prevIds` before calling `updateUniqueIds`, preventing unnecessary `forceUpdate` calls. 
 

### Impact
- Fixes scroll jumps in multi-list scenarios by ensuring only the modified list updates its range.
- Preserves `290bcbd`’s fix for immediate updates in single-list scenarios.
- Improves performance by reducing unnecessary reactivity and range calculations.
- Compatible with all use cases, including single and multi-list setups.

### Test
- Tested with multiple `SolidVirtualList` instances in a parent component which shares a common state data store.
- Verified that updating one list’s `dataSource` does not affect others’ scroll positions.
- Confirmed no regressions in single-list scenarios (e.g., `dataSource` updates redraw correctly per `290bcbd`). 
   
### Notes
- The fix uses Solid’s reactivity in `SolidVirtualList` for efficiency. Alternatively, the `prevIds` logic could be moved to `Virtual.updateUniqueIds` for framework-agnostic use, but this is less idiomatic for SolidJS.
- Future improvements could include debouncing `ResizeObserver` in `VirtualListItem` for added stability. 
- Continuation of `290bcbd`.
 